### PR TITLE
Update _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site settings
 title:          "Առցանց բառարան"
 description:    "Անգլերեն-Հայերեն առցանց բառարան"
-url:            ""
+url:            "https://բառարան.հայ"
 
 # Build settings
 markdown:       kramdown


### PR DESCRIPTION
put the correct url so that robots.txt gives the correct link to Sitemap.xml
currently https://xn--y9aaab7h7a3a.xn--y9a3aq/robots.txt says:
Sitemap: /sitemap.xml
but you need the full path

https://stackoverflow.com/questions/14196801/can-a-relative-sitemap-url-be-used-in-a-robots-txt
https://support.google.com/webmasters/answer/6062596?hl=en
https://github.com/jekyll/jekyll-sitemap